### PR TITLE
INFRA-9023 update module

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -8,23 +8,11 @@ locals {
   security_group_ids = var.create && var.create_security_group ? concat(var.security_group_ids, [aws_security_group.this[0].id]) : var.security_group_ids
 }
 
-data "aws_vpc_endpoint_service" "this" {
-  for_each = local.endpoints
-
-  service      = try(each.value.service, null)
-  service_name = try(each.value.service_name, null)
-
-  filter {
-    name   = "service-type"
-    values = [try(each.value.service_type, "Interface")]
-  }
-}
-
 resource "aws_vpc_endpoint" "this" {
   for_each = local.endpoints
 
   vpc_id            = var.vpc_id
-  service_name      = try(each.value.service_name, data.aws_vpc_endpoint_service.this[each.key].service_name)
+  service_name      = try(each.value.service_name, null)
   vpc_endpoint_type = try(each.value.service_type, "Interface")
   auto_accept       = try(each.value.auto_accept, null)
 

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -24,7 +24,7 @@ resource "aws_vpc_endpoint" "this" {
   for_each = local.endpoints
 
   vpc_id            = var.vpc_id
-  service_name      = try(each.value.service_endpoint, data.aws_vpc_endpoint_service.this[each.key].service_name)
+  service_name      = try(each.value.service_name, data.aws_vpc_endpoint_service.this[each.key].service_name)
   vpc_endpoint_type = try(each.value.service_type, "Interface")
   auto_accept       = try(each.value.auto_accept, null)
 

--- a/modules/vpc-endpoints/variables.tf
+++ b/modules/vpc-endpoints/variables.tf
@@ -22,12 +22,6 @@ variable "security_group_ids" {
   default     = []
 }
 
-variable "service_name" {
-  description = "The service name for the VPC endpoint service. If not provided, the data source will be used."
-  type        = string
-  default     = null
-}
-
 variable "subnet_ids" {
   description = "Default subnets IDs to associate with the VPC endpoints"
   type        = list(string)

--- a/modules/vpc-endpoints/variables.tf
+++ b/modules/vpc-endpoints/variables.tf
@@ -22,6 +22,12 @@ variable "security_group_ids" {
   default     = []
 }
 
+variable "service_name" {
+  description = "The service name for the VPC endpoint service. If not provided, the data source will be used."
+  type        = string
+  default     = null
+}
+
 variable "subnet_ids" {
   description = "Default subnets IDs to associate with the VPC endpoints"
   type        = list(string)


### PR DESCRIPTION
The data source "aws_vpc_endpoint_service" started giving us trouble when the service endpoint was in another AWS account, like for example the prod setup we are doing with MSK private link https://lucid.app/lucidchart/3ca524dc-bb90-4aca-9c1c-e1bdc42cc18f/edit?invitationId=inv_341d7003-e4d1-497c-9f1e-5218af5db1cc&page=9kgGVRD03LaS#

Initially, I was going to add some extra logic to handle both cases, but I have realized that the service_name comes as part of the input, so there is no need to have the data source and this will work for both our use cases.