### PR TITLE
[INFRA-10667] Add support per subnet tags for private subnets by subnet name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -285,7 +285,8 @@ resource "aws_subnet" "private" {
     },
     var.tags,
     var.private_subnet_tags,
-    lookup(var.private_subnet_tags_per_az, element(var.azs, count.index), {})
+    lookup(var.private_subnet_tags_per_az, element(var.azs, count.index), {}),
+    lookup(var.private_subnet_tags_per_name, try(var.private_subnet_names[count.index], ""), {})
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -402,6 +402,12 @@ variable "private_subnet_tags_per_az" {
   default     = {}
 }
 
+variable "private_subnet_tags_per_name" {
+  description = "Additional tags for the private subnets where the primary key is the subnet name"
+  type        = map(map(string))
+  default     = {}
+}
+
 variable "private_route_table_tags" {
   description = "Additional tags for the private route tables"
   type        = map(string)


### PR DESCRIPTION
Unfortunately, due to how we designed the compute VPC and how the upstream VPC module works, we're unable to add specific tags at the per subnet level for the private subnets. This is required so that we can add the required tags for the load balancer controller. There is interest in this type of change at the upstream level, but unfortunately the maintainers do not want this change in this form at all, see https://github.com/terraform-aws-modules/terraform-aws-vpc/pull/901 .  Therefore, we need to apply this small change to our fork for now to work with our use case. 

I'm explicitly not updating the changelog or README docs to minimize the amount of changes so that maintaining these changes with upstream has less conflicts. 