### PR TITLE
feat: INFRA-11828 add condition to data source

### DIFF
--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -10,8 +10,8 @@ locals {
 
 data "aws_vpc_endpoint_service" "this" {
   for_each = {
-      for k, v in local.endpoints : k => v
-      if !try(contains(keys(v), "service_endpoint"), false) # Skip if service_endpoint is defined, needed when the vpc endpoint service is in a different AWS account than the vpc endpoint
+    for k, v in local.endpoints : k => v
+    if !try(contains(keys(v), "service_endpoint"), false) # Skip if service_endpoint is defined, needed when the vpc endpoint service is in a different AWS account than the vpc endpoint
   }
 
   service         = try(each.value.service, null)

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -9,10 +9,10 @@ locals {
 }
 
 data "aws_vpc_endpoint_service" "this" {
-for_each = {
-    for k, v in local.endpoints : k => v
-    if !try(contains(keys(v), "service_endpoint"), false) # Skip if service_endpoint is defined, needed when the vpc endpoint service is in a different AWS account than the vpc endpoint
-}
+  for_each = {
+      for k, v in local.endpoints : k => v
+      if !try(contains(keys(v), "service_endpoint"), false) # Skip if service_endpoint is defined, needed when the vpc endpoint service is in a different AWS account than the vpc endpoint
+  }
 
   service         = try(each.value.service, null)
   service_name    = try(each.value.service_name, null)

--- a/modules/vpc-endpoints/main.tf
+++ b/modules/vpc-endpoints/main.tf
@@ -9,7 +9,10 @@ locals {
 }
 
 data "aws_vpc_endpoint_service" "this" {
-  for_each = local.endpoints
+for_each = {
+    for k, v in local.endpoints : k => v
+    if !try(contains(keys(v), "service_endpoint"), false) # Skip if service_endpoint is defined, needed when the vpc endpoint service is in a different AWS account than the vpc endpoint
+}
 
   service         = try(each.value.service, null)
   service_name    = try(each.value.service_name, null)


### PR DESCRIPTION
This PR introduces a small but critical change to the `modules/vpc-endpoints/main.tf` file to allow the use of **cross-account VPC interface endpoints** (e.g., AWS PrivateLink services hosted in another AWS account).

Currently, the module unconditionally evaluates the `aws_vpc_endpoint_service` data source for every defined endpoint — even if a fully qualified `service_endpoint` is explicitly provided. This leads to failures when trying to use PrivateLink services that:

* Are **not discoverable** via `aws_vpc_endpoint_service` (e.g., they're in another AWS account).
* Have restricted visibility due to **permissions or region scoping**.

### ✅ What This PR Changes

We modify the `for_each` expression of the `data "aws_vpc_endpoint_service"` block to **skip evaluation if `service_endpoint` is provided**, since in that case the lookup is unnecessary and can cause errors.

### 🎯 Why This Change Is Needed

* It enables support for **cross-account PrivateLink usage** by allowing `service_endpoint` to be passed directly without triggering a data source lookup.
* Avoids Terraform plan/apply failures when the PrivateLink service is **not visible in the current account**.
* Keeps the module **backward-compatible** — existing use cases where `service_endpoint` is not defined will continue to work exactly as before.